### PR TITLE
Buy&done page create

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@
 |![商品一覧max](https://user-images.githubusercontent.com/54468465/89701716-788a8880-d974-11ea-99c0-cb8059b6a8f1.png)|![商品一覧min](https://user-images.githubusercontent.com/54468465/89701719-7de7d300-d974-11ea-8da2-839f98fdee3c.png)|
 |商品詳細|
 |![商品詳細ページmax](https://user-images.githubusercontent.com/54468465/89732730-b8905f00-da8b-11ea-9ea5-e85e64594361.png)|![商品詳細ページmin](https://user-images.githubusercontent.com/54468465/89732738-c219c700-da8b-11ea-8415-736d511b9677.png)|
+|商品購入|
+|![商品購入ページmax](https://user-images.githubusercontent.com/54468465/89985077-6894e080-dcb5-11ea-8e66-f9feaffda068.png)|![商品購入ページmin](https://user-images.githubusercontent.com/54468465/89985103-75b1cf80-dcb5-11ea-84f5-b89009854faa.png)|
+|購入完了|
+|![購入完了ページmax](https://user-images.githubusercontent.com/54468465/89985121-7c404700-dcb5-11ea-8cbb-da0f99790d85.png)|![購入完了ページmin](https://user-images.githubusercontent.com/54468465/89985133-819d9180-dcb5-11ea-88a4-3461f0c5360e.png)|
 |お問い合わせ|
 |![お問い合わせmax](https://user-images.githubusercontent.com/54468465/88474522-4899b900-cf62-11ea-8270-61c16e78c612.png)|![お問い合わせmin](https://user-images.githubusercontent.com/54468465/88474547-8860a080-cf62-11ea-9f1d-57540857ec35.png)|
 |管理者ページ|

--- a/app/assets/javascripts/navi.js
+++ b/app/assets/javascripts/navi.js
@@ -10,4 +10,9 @@ window.onload = function(){
     $('.buttom').toggleClass('hidden');
     $('.buttom__btn').toggleClass('hidden');
   });
+
+  $(document).on('click', '.checkout__container__content__body__box__right__response', function(){
+    $('.checkout__container__content__body__box__right__response__text').toggleClass('hidden');
+    $('.checkout__container__content__body__box__right__overview').toggleClass('hidden');
+  });
 };

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,8 @@
 // productsで使用するscss
 @import "./products/index";
 @import "./products/show";
+@import "./products/checkout";
+@import "./products/done";
 
 // adminsで使用するscss
 @import "./admins/index";

--- a/app/assets/stylesheets/partial/_color_variable.scss
+++ b/app/assets/stylesheets/partial/_color_variable.scss
@@ -14,3 +14,4 @@ $dark-green: #00838f;
 $midlle-green: #5bc8ac;
 
 $gray: #545454;
+$light-gray: #909090;

--- a/app/assets/stylesheets/partial/_mixin.scss
+++ b/app/assets/stylesheets/partial/_mixin.scss
@@ -41,6 +41,20 @@
   display: inline-block;
   cursor: pointer;
   text-align: center;
+  font-family: "-apple-system", 游ゴシック体, "Yu Gothic", YuGothic, "ヒラギノ角ゴシック Pro", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, Osaka, "ＭＳ Ｐゴシック", "MS PGothic", sans-serif;
+  font-weight: bold;
+  font-size: 16px;
+}
+
+// select-box
+@mixin select-box() {
+  width: 100%;
+  height: 40px;
+  border: 1px solid $gray;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+  padding-left: 0.5em;
 }
 // 共通.scss終わり
 

--- a/app/assets/stylesheets/partial/_mixin.scss
+++ b/app/assets/stylesheets/partial/_mixin.scss
@@ -40,6 +40,7 @@
   width: 100%;
   display: inline-block;
   cursor: pointer;
+  text-align: center;
 }
 // 共通.scss終わり
 

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -1,0 +1,17 @@
+.checkout{
+
+  &__container{
+
+    &__content {
+      @include container-padding-max();
+
+      &__title{
+        @include title-max();
+      }
+
+      &__body{
+        @include container-body-padding-max();
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -63,62 +63,81 @@
               display: none;
             }
 
-            &__list{
-              display: flex;
-              align-items: center;
+            &__overview{
 
-              &__image{
-                width: 5rem;
-                height: 5rem;
+              &__list{
+                display: flex;
+                align-items: center;
 
-                img{
-                  width: 100%;
-                  height: 100%;
-                  object-fit: cover;
+                &__image{
+                  width: 5rem;
+                  height: 5rem;
+
+                  img{
+                    width: 100%;
+                    height: 100%;
+                    object-fit: cover;
+                  }
+                }
+
+                &__info{
+                  padding-left: 1rem;
+
+                  &__sex::before{
+                    content: "性別：";
+                  }
+
+                  &__size::before{
+                    content: "サイズ：";
+                  }
+                }
+
+                &__price{
+                  margin-left: auto;
                 }
               }
 
-              &__info{
-                padding-left: 1rem;
+              &__comment{
+                padding-top: 1.5rem;
+              }
+              
+              &__comment::before{
+                content: "コメント：";
               }
 
-              &__price{
-                margin-left: auto;
+              &__discount{
+                display: flex;
+                margin: 2rem 0;
+                padding: 1.5rem 0;
+                border-top: solid 1px #ddd;
+                border-bottom: solid 1px #ddd;
+
+                .select-box{
+                  @include select-box();
+                  margin-top: 0;
+                  width: 65%;
+                }
+
+                .discount-button{
+                  @include button();
+                  background-color: $gray;
+                  width: 30%;
+                  padding: 0;
+                  margin-left: auto;
+                  height: 40px;
+                }
               }
-            }
 
-            &__discount{
-              display: flex;
-              margin: 2rem 0;
-              padding: 1.5rem 0;
-              border-top: solid 1px #ddd;
-              border-bottom: solid 1px #ddd;
+              &__total{
+                display: flex;
+                align-items: center;
+                padding: 1.5rem 0;
 
-              .select-box{
-                @include select-box();
-                margin-top: 0;
-                width: 65%;
-              }
-
-              .discount-button{
-                @include button();
-                background-color: $gray;
-                width: 30%;
-                padding: 0;
-                margin-left: auto;
-                height: 40px;
-              }
-            }
-
-            &__total{
-              display: flex;
-              align-items: center;
-              padding: 1.5rem 0;
-
-              &__price{
-                margin-left: auto;
-                color: black;
-                font-size: 24px;
+                &__price{
+                  margin-left: auto;
+                  color: black;
+                  font-size: 24px;
+                }
               }
             }
           }
@@ -129,6 +148,20 @@
 }
 
 @media screen and (max-width: 1023px){
+
+  // ↓display:none; だと、transitionが効かないのでkeyframesを入れる
+  @keyframes tooltipShow {
+    from {
+      opacity: 0;
+      transform: translateY(5px);
+    }
+  
+    to {
+      opacity: 1;
+      transform: translateY(0px);
+    }
+  }
+
   .checkout{
   
     &__container {
@@ -153,20 +186,56 @@
               width: 100%;
               border: 1rem;
 
+              &__response:active{
+                border-radius: 0.6rem 0.6rem 0 0;
+              }
+
               &__response{
                 @include button();
                 background-color: #fafafa;
                 border: 1px solid #e6e6e6;
                 display: flex;
+                box-shadow: 0 0 0 0;
                 
                 &__text{
                   color: $midlle-blue;
+                }
+
+                &__text:after{
+                  transition: -webkit-transform .3s;
+                  transition: transform .3s;
+                  transition: transform .3s, -webkit-transform .3s;
+                  -webkit-transform: rotate(180deg);
+                  transform: rotate(180deg);
+                  display: inline-block;
+                  width: 18px;
+                  height: 18px;
+                  content: "\f077";
+                  font-family: FontAwesome;
+                }
+
+                &__text.hidden:after{
+                  -webkit-transform: rotate(0deg);
+                  transform: rotate(0deg);
                 }
 
                 &__price{
                   color: black;
                   margin-left: auto;
                 }
+              }
+
+              &__overview{
+                border: 10px solid #fafafa;
+                padding: 10px;
+                border-radius: 0.6rem;
+                display: none;
+              }
+
+              &__overview.hidden{
+                display: block;
+                // ↓keyframesと連動している
+                animation: tooltipShow 0.3s linear 0s;
               }
             }
           }
@@ -182,7 +251,7 @@
     &__container{
   
       &__content {
-        @include container-padding-max639px();
+        padding: 0 0 1rem 0;
 
         &__title{
           @include title-max639px();
@@ -193,21 +262,23 @@
           &__box{
           
             &__right{
-            
-              &__list{
-                display: block;
 
-                &__image{
-                  width: 100%;
-                  height: auto;
-                }
+              &__overview{
+                &__list{
+                  display: block;
 
-                &__info{
-                  padding: 1rem 0 0 0;
-                }
+                  &__image{
+                    width: 100%;
+                    height: auto;
+                  }
 
-                &__price::before{
-                  content: "価格：";
+                  &__info{
+                    padding: 1rem 0 0 0;
+                  }
+
+                  &__price::before{
+                    content: "価格：";
+                  }
                 }
               }
             }

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -264,6 +264,7 @@
             &__right{
 
               &__overview{
+                
                 &__list{
                   display: block;
 

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -11,6 +11,162 @@
 
       &__body{
         @include container-body-padding-max();
+
+        &__box{
+          display: flex;
+
+          &__left{
+            width: 48%;
+            margin-right: auto;
+
+            &__contact , &__claim{
+
+              .select-box{
+                @include select-box();
+                margin-top: 1rem;
+              }
+
+              &__post{
+                display: -webkit-flex;
+                display: flex;
+                -webkit-align-items: center; /* 縦方向中央揃え（Safari用） */
+                align-items: center; /* 縦方向中央揃え */
+                -webkit-justify-content: center; /* 横方向中央揃え（Safari用） */
+                justify-content: center; /* 横方向中央揃え */
+
+                span{
+                  margin: 1rem 1rem 0 1rem;
+                }
+              }
+            }
+
+            &__claim{
+              padding-top: 2rem;
+            }
+
+            .buy-button{
+              margin-top: 2rem;
+              background-color: $dark-red;
+              @include button();
+            }
+          }
+
+          &__right{
+            width: 48%;
+            margin-left: auto;
+
+            &__list{
+              display: flex;
+              align-items: center;
+
+              &__image{
+                width: 5rem;
+                height: 5rem;
+
+                img{
+                  width: 100%;
+                  height: 100%;
+                  object-fit: cover;
+                }
+              }
+
+              &__info{
+                padding-left: 1rem;
+              }
+
+              &__price{
+                margin-left: auto;
+              }
+            }
+
+            &__discount{
+              display: flex;
+              margin: 2rem 0;
+              padding: 1.5rem 0;
+              border-top: solid 1px #ddd;
+              border-bottom: solid 1px #ddd;
+
+              .select-box{
+                @include select-box();
+                margin-top: 0;
+                width: 65%;
+              }
+
+              .discount-button{
+                @include button();
+                background-color: $gray;
+                width: 30%;
+                padding: 0;
+                margin-left: auto;
+                height: 40px;
+              }
+            }
+
+            &__total{
+              display: flex;
+              align-items: center;
+              padding: 1.5rem 0;
+
+              &__price{
+                margin-left: auto;
+                color: black;
+                font-size: 24px;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (min-width: 1024px){
+  .checkout__container__content__body__box__center{
+    border: solid 1px #ddd;
+  }
+}
+
+@media screen and (max-width: 1023px){
+  .checkout{
+  
+    &__container {
+  
+      &__content{
+        @include container-padding-max1023px();
+
+        &__body{
+  
+          &__box{
+            display: block;
+
+            &__left{
+              width: 100%;
+            }
+
+            &__right{
+              width: 100%;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 639px){
+  .checkout{
+  
+    &__container{
+  
+      &__content {
+        @include container-padding-max639px();
+
+        &__title{
+          @include title-max639px();
+        }
+        &__body{
+          @include container-body-padding-max639px();
+        }
       }
     }
   }

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -59,6 +59,10 @@
             width: 48%;
             margin-left: auto;
 
+            &__response{
+              display: none;
+            }
+
             &__list{
               display: flex;
               align-items: center;
@@ -147,6 +151,23 @@
 
             &__right{
               width: 100%;
+              border: 1rem;
+
+              &__response{
+                @include button();
+                background-color: #fafafa;
+                border: 1px solid #e6e6e6;
+                display: flex;
+                
+                &__text{
+                  color: $midlle-blue;
+                }
+
+                &__price{
+                  color: black;
+                  margin-left: auto;
+                }
+              }
             }
           }
         }

--- a/app/assets/stylesheets/products/checkout.scss
+++ b/app/assets/stylesheets/products/checkout.scss
@@ -51,6 +51,10 @@
             }
           }
 
+          &__center{
+            border: solid 1px #ddd;
+          }
+
           &__right{
             width: 48%;
             margin-left: auto;
@@ -120,12 +124,6 @@
   }
 }
 
-@media screen and (min-width: 1024px){
-  .checkout__container__content__body__box__center{
-    border: solid 1px #ddd;
-  }
-}
-
 @media screen and (max-width: 1023px){
   .checkout{
   
@@ -137,10 +135,14 @@
         &__body{
   
           &__box{
-            display: block;
+            flex-direction: column-reverse;
 
             &__left{
               width: 100%;
+            }
+
+            &__center{
+              margin: 2rem 0;
             }
 
             &__right{
@@ -166,6 +168,29 @@
         }
         &__body{
           @include container-body-padding-max639px();
+
+          &__box{
+          
+            &__right{
+            
+              &__list{
+                display: block;
+
+                &__image{
+                  width: 100%;
+                  height: auto;
+                }
+
+                &__info{
+                  padding: 1rem 0 0 0;
+                }
+
+                &__price::before{
+                  content: "価格：";
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/app/assets/stylesheets/products/done.scss
+++ b/app/assets/stylesheets/products/done.scss
@@ -1,0 +1,166 @@
+.done{
+
+  &__container{
+
+    &__content {
+      @include container-padding-max();
+
+      &__title{
+        @include title-max();
+      }
+
+      &__body{
+        @include container-body-padding-max();
+
+        &__thanks{
+          text-align: center;
+          padding-bottom: 3rem;
+          font-size: 1.5rem;
+        }
+
+        &__box{
+          width: 100%;
+
+          &__list{
+            display: flex;
+            align-items: center;
+
+            &__image{
+              width: 5rem;
+              height: 5rem;
+
+              img{
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+              }
+            }
+
+            &__info{
+              padding-left: 1rem;
+
+              &__sex::before{
+                content: "性別：";
+              }
+
+              &__size::before{
+                content: "サイズ：";
+              }
+            }
+
+            &__price{
+              margin-left: auto;
+            }
+          }
+
+          &__comment{
+            padding-top: 1.5rem;
+          }
+          
+          &__comment::before{
+            content: "コメント：";
+          }
+
+          &__total{
+            display: flex;
+            align-items: center;
+            padding: 1.5rem 0;
+
+            &__price{
+              margin-left: auto;
+              color: black;
+              font-size: 24px;
+            }
+          }
+
+          &__attention{
+            text-align: center;
+          }
+
+          &__address{
+            text-align: center;
+            padding: 3rem 0;
+            
+
+            &__title{
+              font-size: 1.5rem;
+            }
+
+            &__detail{
+              padding: 1rem 0;
+            }
+          }
+
+          .top-button{
+            background-color: $dark-blue;
+            @include button();
+          }
+        }
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 1023px){
+  .done{
+  
+    &__container {
+  
+      &__content{
+        @include container-padding-max1023px();
+      }
+    }
+  }
+}
+
+@media screen and (max-width: 639px){
+  .done{
+  
+    &__container{
+  
+      &__content {
+        @include container-padding-max639px();
+
+        &__title{
+          @include title-max639px();
+        }
+        &__body{
+          @include container-body-padding-max639px();
+
+          &__thanks{
+            font-size: 1rem;
+            padding-bottom: 1rem;
+          }
+
+          &__box{
+
+            &__list{
+              display: block;
+
+              &__image{
+                width: 100%;
+                height: auto;
+              }
+
+              &__info{
+                padding: 1rem 0 0 0;
+              }
+
+              &__price::before{
+                content: "価格：";
+              }
+            }
+
+            &__address{
+              padding: 1rem 0;
+  
+              &__title{
+                font-size: 1rem;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/products/index.scss
+++ b/app/assets/stylesheets/products/index.scss
@@ -121,9 +121,6 @@
   
       &__content {
 
-        &__title{
-
-        }
         &__body{
 
           &__ul{
@@ -184,9 +181,6 @@
 
         &__title{
           @include title-max639px();
-        }
-        &__body{
-
         }
       }
     }

--- a/app/assets/stylesheets/products/show.scss
+++ b/app/assets/stylesheets/products/show.scss
@@ -75,13 +75,7 @@
                 &__size, &__sex{
 
                   .select-box{
-                    width: 100%;
-                    height: 40px;
-                    border: 1px solid $gray;
-                    border-radius: 0.4rem;
-                    cursor: pointer;
-                    margin-top: 0.5rem;
-                    padding-left: 0.5em;
+                    @include select-box();
                   }
                 }
               }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,2 +1,5 @@
 class ProductsController < ApplicationController
+  def checkout
+    render :layout => "application_second_layout"
+  end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,11 @@
 class ProductsController < ApplicationController
   def checkout
+    # application_second_layout.html.hamlを読み込ませる
+    render :layout => "application_second_layout"
+  end
+
+  def done
+    # application_second_layout.html.hamlを読み込ませる
     render :layout => "application_second_layout"
   end
 end

--- a/app/views/layouts/application_second_layout.html.haml
+++ b/app/views/layouts/application_second_layout.html.haml
@@ -1,0 +1,14 @@
+!!!
+%html
+  %head
+    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta{:content => "width=device-width", :name => "viewport"}/
+    %script{src:"https://kit.fontawesome.com/251f98a839.js" ,crossorigin:"anonymous"}
+    %title Rekimo
+    = csrf_meta_tags
+    = csp_meta_tag
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = favicon_link_tag
+  %body{ style: "margin: 0;" }
+    = yield

--- a/app/views/partial/home/contact/_question.html.haml
+++ b/app/views/partial/home/contact/_question.html.haml
@@ -1,14 +1,19 @@
 .cp_qa
   .cp_actab
     %input{id:"cp_tabfour031" , type:"checkbox" , name:"tabs"}
-    %label{for:"cp_tabfour031"} 質問テキスト
+    %label{for:"cp_tabfour031"} 着物はどちらに発送すればいいですか？
     .cp_actab-content
-      %p 答えテキスト
+      %p 〒 578-0936
+      %p 大阪府東大阪市花園西町1-14-11
+      %p 岩内 美八重 宛
+      %p までよろしくお願いいたします。
   .cp_actab
     %input{id:"cp_tabfour032" , type:"checkbox" , name:"tabs"}
-    %label{for:"cp_tabfour032"} 質問テキスト
+    %label{for:"cp_tabfour032"} サイズは指定できますか？
     .cp_actab-content
-      %p 答えテキスト
+      %p 可能です。
+      %p ご購入の際にコメント欄を設けておりますので、着丈・バスト・袖丈・肩幅のご指定をよろしくお願いいたします。
+      %p ※ただし、既製品につきましては製作済みのため不可です。ご了承くださいませ。
   .cp_actab
     %input{id:"cp_tabfour033" , type:"checkbox" , name:"tabs"}
     %label{for:"cp_tabfour033"} 質問テキスト

--- a/app/views/products/checkout.html.haml
+++ b/app/views/products/checkout.html.haml
@@ -29,6 +29,11 @@
             %button.buy-button{type:"submit" , id:"buy_button"} お支払いへ進む
           .checkout__container__content__body__box__center
           %aside.checkout__container__content__body__box__right
+            %button.checkout__container__content__body__box__right__response
+              .checkout__container__content__body__box__right__response__text
+                %span 注文概要・クーポン入力
+              %p.checkout__container__content__body__box__right__response__price
+                25,000円
             .checkout__container__content__body__box__right__list
               .checkout__container__content__body__box__right__list__image
                 = image_tag "product-img.jpg"

--- a/app/views/products/checkout.html.haml
+++ b/app/views/products/checkout.html.haml
@@ -4,3 +4,47 @@
       .checkout__container__content__title
         %span 商品購入ページ
       .checkout__container__content__body
+        .checkout__container__content__body__box
+          .checkout__container__content__body__box__left
+            .checkout__container__content__body__box__left__contact
+              %p.Form__Item__Label
+                %span.Form__Item__Label__Required 必須
+                連絡先情報
+              %input{type:"text" , class:"select-box" , placeholder:"メールアドレス"}
+              %input{type:"text" , class:"select-box" , placeholder:"電話番号"}
+            .checkout__container__content__body__box__left__claim
+              %p.Form__Item__Label
+                %span.Form__Item__Label__Required 必須
+                請求先情報
+              %input{type:"text" , class:"select-box" , placeholder:"姓名"}
+              .checkout__container__content__body__box__left__claim__post
+                %span{ style: "margin-left: 0;" } 〒
+                %input{type:"text" , class:"select-box" , placeholder:"000"}
+                %span ー
+                %input{type:"text" , class:"select-box" , placeholder:"0000"}
+              %select.select-box{prompt: "--"}
+              %input{type:"text" , class:"select-box" , placeholder:"市区名"}
+              %input{type:"text" , class:"select-box" , placeholder:"町村名、番地"}
+              %input{type:"text" , class:"select-box" , placeholder:"建物名、部屋番号など（任意）"}
+            %button.buy-button{type:"submit" , id:"buy_button"} お支払いへ進む
+          .checkout__container__content__body__box__center
+          %aside.checkout__container__content__body__box__right
+            .checkout__container__content__body__box__right__list
+              .checkout__container__content__body__box__right__list__image
+                = image_tag "product-img.jpg"
+              .checkout__container__content__body__box__right__list__info
+                %p.checkout__container__content__body__box__right__list__info__title
+                  テーラード・ジャケット
+                %p.checkout__container__content__body__box__right__list__info__sex
+                  性別：男性
+                %p.checkout__container__content__body__box__right__list__info__size
+                  サイズ：L
+              %p.checkout__container__content__body__box__right__list__price
+                25,000円
+            .checkout__container__content__body__box__right__discount
+              %input{type:"text" , class:"select-box" , placeholder:"Gift Cord"}
+              %button.discount-button{type:"button" , id:"discount_button"} 適用する
+            .checkout__container__content__body__box__right__total
+              %p 合計
+              %p.checkout__container__content__body__box__right__total__price
+                25,000円

--- a/app/views/products/checkout.html.haml
+++ b/app/views/products/checkout.html.haml
@@ -7,13 +7,13 @@
         .checkout__container__content__body__box
           .checkout__container__content__body__box__left
             .checkout__container__content__body__box__left__contact
-              %p.Form__Item__Label
+              %p.Form__Item__Label{style:"margin: 0;"}
                 %span.Form__Item__Label__Required 必須
                 連絡先情報
               %input{type:"text" , class:"select-box" , placeholder:"メールアドレス"}
               %input{type:"text" , class:"select-box" , placeholder:"電話番号"}
             .checkout__container__content__body__box__left__claim
-              %p.Form__Item__Label
+              %p.Form__Item__Label{style:"margin: 0;"}
                 %span.Form__Item__Label__Required 必須
                 請求先情報
               %input{type:"text" , class:"select-box" , placeholder:"姓名"}
@@ -34,22 +34,25 @@
                 %span 注文概要・クーポン入力
               %p.checkout__container__content__body__box__right__response__price
                 25,000円
-            .checkout__container__content__body__box__right__list
-              .checkout__container__content__body__box__right__list__image
-                = image_tag "product-img.jpg"
-              .checkout__container__content__body__box__right__list__info
-                %p.checkout__container__content__body__box__right__list__info__title
-                  テーラード・ジャケット
-                %p.checkout__container__content__body__box__right__list__info__sex
-                  性別：男性
-                %p.checkout__container__content__body__box__right__list__info__size
-                  サイズ：L
-              %p.checkout__container__content__body__box__right__list__price
-                25,000円
-            .checkout__container__content__body__box__right__discount
-              %input{type:"text" , class:"select-box" , placeholder:"Gift Cord"}
-              %button.discount-button{type:"button" , id:"discount_button"} 適用する
-            .checkout__container__content__body__box__right__total
-              %p 合計
-              %p.checkout__container__content__body__box__right__total__price
-                25,000円
+            .checkout__container__content__body__box__right__overview
+              .checkout__container__content__body__box__right__overview__list
+                .checkout__container__content__body__box__right__overview__list__image
+                  = image_tag "product-img.jpg"
+                .checkout__container__content__body__box__right__overview__list__info
+                  %p.checkout__container__content__body__box__right__overview__list__info__title
+                    テーラード・ジャケット
+                  %p.checkout__container__content__body__box__right__overview__list__info__sex
+                    男性
+                  %p.checkout__container__content__body__box__right__overview__list__info__size
+                    L
+                %p.checkout__container__content__body__box__right__overview__list__price
+                  25,000円
+              %p.checkout__container__content__body__box__right__overview__comment
+                着丈は〇〇cm、バストは〇〇cm、袖丈は〇〇cm、肩幅は〇〇cmでお願いします。
+              .checkout__container__content__body__box__right__overview__discount
+                %input{type:"text" , class:"select-box" , placeholder:"Gift Cord"}
+                %button.discount-button{type:"button" , id:"discount_button"} 適用する
+              .checkout__container__content__body__box__right__overview__total
+                %p 合計
+                %p.checkout__container__content__body__box__right__overview__total__price
+                  25,000円

--- a/app/views/products/checkout.html.haml
+++ b/app/views/products/checkout.html.haml
@@ -1,1 +1,6 @@
-商品購入ページ
+.checkout
+  .checkout__container
+    .checkout__container__content
+      .checkout__container__content__title
+        %span 商品購入ページ
+      .checkout__container__content__body

--- a/app/views/products/done.html.haml
+++ b/app/views/products/done.html.haml
@@ -1,1 +1,45 @@
-購入完了ページ
+.done
+  .done__container
+    .done__container__content
+      .done__container__content__title
+        %span 購入完了ページ
+      .done__container__content__body
+        %p.done__container__content__body__thanks
+          ご購入ありがとうございます。
+        .done__container__content__body__box
+          .done__container__content__body__box__list
+            .done__container__content__body__box__list__image
+              = image_tag "product-img.jpg"
+            .done__container__content__body__box__list__info
+              %p.done__container__content__body__box__list__info__title
+                テーラード・ジャケット
+              %p.done__container__content__body__box__list__info__sex
+                男性
+              %p.done__container__content__body__box__list__info__size
+                L
+            %p.done__container__content__body__box__list__price
+              25,000円
+          %p.done__container__content__body__box__comment
+            着丈は〇〇cm、バストは〇〇cm、袖丈は〇〇cm、肩幅は〇〇cmでお願いします。
+          .done__container__content__body__box__total
+            %p お支払い金額の合計
+            %p.done__container__content__body__box__total__price
+              25,000円
+          %p.done__container__content__body__box__attention
+            既製品をご購入の場合はこのまま商品到着までお待ちください。
+            %br
+            着物をリメイクされる場合は下記まで発送の程、よろしくお願いいたします。
+            %br
+            送料はお手数ですが、元払い発送でご協力願います。
+          .done__container__content__body__box__address
+            %p.done__container__content__body__box__address__title
+              発送先
+            %p.done__container__content__body__box__address__detail
+              〒 578-0936
+              %br
+              大阪府東大阪市花園西町1-14-11
+              %br
+              岩内 美八重 宛
+              %br
+              までよろしくお願いいたします。
+          = link_to 'トップページに戻る' , root_path , class: "top-button"

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -47,4 +47,4 @@
                 %span.Form__Item__Label__Any 任意
                 %label.label-text コメント欄
                 %textarea{class:"comment-area" , placeholder:"例）着丈は〇〇cm、バストは〇〇cm、袖丈は〇〇cm、肩幅は〇〇cmでお願いします。"}
-              %input{type:"button" , class:"buy-button" , value:"購入画面に進む"}
+              = link_to '購入画面に進む' , product_checkout_path(1) , class: "buy-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,12 +9,9 @@ Rails.application.routes.draw do
 
   # 商品一覧
   resources :products do
-    # idは不要なのでcollectionを使用
-    collection do
-      # 商品購入ページ 購入完了ページ
-      get 'checkout'
-      get 'done'
-     end
+    # 商品購入ページ 購入完了ページ
+    get 'checkout'
+    post 'done'
   end
 
   # 管理者ページ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,15 +3,17 @@ Rails.application.routes.draw do
   # トップページ
   root to: 'homes#home'
 
-  # 料金一覧 よくある質問 お問い合わせ
+  # 料金一覧
   get 'homes/service', to: 'homes#service'
+  # お問い合わせ
   get 'homes/contact', to: 'homes#contact'
 
   # 商品一覧
   resources :products do
-    # 商品購入ページ 購入完了ページ
+    # 商品購入ページ
     get 'checkout'
-    post 'done'
+    # 購入完了ページ
+    get 'done'
   end
 
   # 管理者ページ


### PR DESCRIPTION
# What
商品購入ページと購入完了ページのviewを生成。

# Why
ユーザーが商品を購入できるように、また購入できたかを確認できるようにするためです。

# 備考
・実際の見た目
商品購入ページ
①通常
![商品購入ページmax](https://user-images.githubusercontent.com/54468465/89985077-6894e080-dcb5-11ea-8e66-f9feaffda068.png)
②レスポンス
![商品購入ページmin](https://user-images.githubusercontent.com/54468465/89985103-75b1cf80-dcb5-11ea-84f5-b89009854faa.png)
購入完了ページ
①通常
![購入完了ページmax](https://user-images.githubusercontent.com/54468465/89985121-7c404700-dcb5-11ea-8cbb-da0f99790d85.png)
②レスポンス
![購入完了ページmin](https://user-images.githubusercontent.com/54468465/89985133-819d9180-dcb5-11ea-88a4-3461f0c5360e.png)